### PR TITLE
Fix 404 error when creating Unit from route with Module ID

### DIFF
--- a/app/Filament/Resources/CourseUnitResource.php
+++ b/app/Filament/Resources/CourseUnitResource.php
@@ -54,21 +54,21 @@ class CourseUnitResource extends Resource
                 Tables\Columns\TextColumn::make('module.title'),
             ])
             ->actions([
-                Action::make('units')->url(fn($record): string => url('admin/courses/modules/'.$record->id)),
+                Action::make('units')->url(fn($record): string => url('admin/courses/modules/' . $record->id)),
                 Tables\Actions\EditAction::make(),
             ])
             ->bulkActions([
                 Tables\Actions\DeleteBulkAction::make(),
             ]);
     }
-    
+
     public static function getPages(): array
     {
         return [
             'index' => Pages\ListCourseUnits::route('/'),
             'modules' => Pages\ListCourseUnits::route('/{record}'),
-            'modules/units' => Pages\CreateCourseUnit::route('/create'),
+            'modules/units' => Pages\CreateCourseUnit::route('/{record}/create'),
             'edit' => Pages\EditCourseUnit::route('/{record}/edit'),
         ];
-    }    
+    }
 }


### PR DESCRIPTION
When attempting to create a Unit, for example, from "/admin/courses/modules/units/1," the administrator encounters an error: "404 | Not Found."

The PullRequest aims to fix this issue by modifying the "create" route to include the Module ID.